### PR TITLE
Automatic-Module-Name added to the manifest.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,17 @@
         </executions>
       </plugin>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.spotify.futures</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.13</version>


### PR DESCRIPTION
As described by http://branchandbound.net/blog/java/2017/12/automatic-module-name/ , adding `Automatic-Module-Name` allows us to move to Java 11 without worrying that the jar file name will change.