### PR TITLE
JPMS support for real.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,12 @@ secure: "PESEMT6CyhKp6zq1JTZ4Lyp8OBTZsNXUzAQyTSSRUDnopk+PHPGHOIjHisRdesM3d2uxgpE
 language: java
 
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 
 install:
   - mvn install -DskipTests=true -Dgpg.skip=true
 
-# Build using JDK 8 and then run tests for 8, 7 and 6.
 script:
-  - jdk_switcher use oraclejdk8
   - mvn test
 
 after_success:

--- a/pom.xml
+++ b/pom.xml
@@ -190,40 +190,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.17</version>
-        <configuration>
-          <configLocation>checkstyle.xml</configLocation>
-          <consoleOutput>true</consoleOutput>
-          <failOnViolation>true</failOnViolation>
-          <failsOnError>true</failsOnError>
-          <maxAllowedViolations>0</maxAllowedViolations>
-          <!-- checkstyle does not support JPMS yet -->
-          <excludes>**/module-info.java</excludes>
-        </configuration>
-        <executions>
-          <execution>
-            <id>checkstyle</id>
-            <phase>process-sources</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <configuration>
-              <failOnViolation>true</failOnViolation>
-              <failsOnError>true</failsOnError>
-            </configuration>
-          </execution>
-        </executions>
-        <dependencies>
-          <dependency>
-            <groupId>com.puppycrawl.tools</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>8.15</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>3.0.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,11 +68,13 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>26.0-jre</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>api-common</artifactId>
       <version>1.7.0</version>
+      <optional>true</optional>
     </dependency>
 
     <!-- test dependencies -->
@@ -126,16 +128,36 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.8.0</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>8</release>
         </configuration>
+        <executions>
+          <!-- build everything for Java 11: -->
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <release>11</release>
+            </configuration>
+          </execution>
+          <!-- then re-build everything except module-info for Java 8: -->
+          <execution>
+            <id>base-compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <excludes>
+                <exclude>module-info.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2</version>
+        <version>3.0.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -153,10 +175,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.8.1</version>
+        <version>3.0.1</version>
         <configuration>
           <show>private</show>
-          <additionalparam>-Xdoclint:none</additionalparam>
+          <failOnError>false</failOnError>
         </configuration>
         <executions>
           <execution>
@@ -168,26 +190,17 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>3.1.0</version>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>com.spotify.futures</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.13</version>
+        <version>2.17</version>
         <configuration>
           <configLocation>checkstyle.xml</configLocation>
           <consoleOutput>true</consoleOutput>
           <failOnViolation>true</failOnViolation>
           <failsOnError>true</failsOnError>
           <maxAllowedViolations>0</maxAllowedViolations>
+          <!-- checkstyle does not support JPMS yet -->
+          <excludes>**/module-info.java</excludes>
         </configuration>
         <executions>
           <execution>
@@ -206,7 +219,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>5.9</version>
+            <version>8.15</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+module com.spotify.futures {
+  /*
+   * com.google.guava:guava,
+   * dependency is optional in case only CompletionStage
+   * and/or ApiFuture are required:
+   */
+  requires static com.google.common;
+  /*
+   * com.google.api:api-common,
+   * dependency is optional in case only CompletionStage
+   * and/or ListenableFuture are required:
+   */
+  requires static api.common;
+}


### PR DESCRIPTION
The recommended way to make a library JPMS-compatible, yet preserve backward-compatibility with Java 8.

Includes following changes:
1. building with java 11, then re-building with java 8 except for module-info.
2. javadoc `Xdoclint` is not supported, replaced with `failOnError=false`.
3. checkstyle does not support `module-info` yet, excluded.
4. since the library can be used for any of working with `CompletionStage`, `ApiFuture` and `ListenableFuture`, the module declares them as compile-time dependencies (maven changed accordingly).