### PR TITLE
Bump to stable dependencies and make the non-optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,14 +67,12 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>26.0-jre</version>
-      <optional>true</optional>
+      <version>28.0-jre</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>api-common</artifactId>
-      <version>1.7.0</version>
-      <optional>true</optional>
+      <version>1.8.1</version>
     </dependency>
 
     <!-- test dependencies -->

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -26,5 +26,5 @@ module com.spotify.futures {
    * dependency is optional in case only CompletionStage
    * and/or ListenableFuture are required:
    */
-  requires static api.common;
+  requires static com.google.api.apicommon;
 }


### PR DESCRIPTION
In guava 28 the Futures API has been stabilized. As such, we should
expect that futures-extra will work across future guava versions. Thus,
there is less risk to keeping dependencies as non-optional (and thus
be backwards compatible with 4.1.1,
https://github.com/spotify/futures-extra/issues/38).

This change also bumps api-commons which includes a change in the JPMS
module name.