### PR TITLE
Bump junit and guava versions to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>29.0-jre</version>
+      <version>32.1.2-jre</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This fixes the CVEs marked in https://github.com/spotify/futures-extra/issues/54. All tests pass on my machine.

Can someone merge and make a new release? (@spkrka ?)

Even with the standard master code I had to:
1) use JDK11 for the build to work
2) Skip checkstyle (`mvn clean test package verify -Dcheckstyle.skip=true`)

Otherwise, to run checkstyle I'd have to bump checkstyle to 3.3.0 and change the `checkstyle.xml` to be compatible with their new configuration format and APIs.